### PR TITLE
Generalises partial application with holes

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,518 @@
+{
+  "name": "furipota",
+  "version": "0.2.0",
+  "lockfileVersion": 1,
+  "dependencies": {
+    "ansi-regex": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
+      "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8="
+    },
+    "ansi-styles": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
+      "integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4="
+    },
+    "argparse": {
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.9.tgz",
+      "integrity": "sha1-c9g7wmP4bpf4zE9rrhsOkKfSLIY="
+    },
+    "babel-code-frame": {
+      "version": "6.22.0",
+      "resolved": "https://registry.npmjs.org/babel-code-frame/-/babel-code-frame-6.22.0.tgz",
+      "integrity": "sha1-AnYgvuVnqIwyVhV05/0IAdMxGOQ="
+    },
+    "babel-messages": {
+      "version": "6.23.0",
+      "resolved": "https://registry.npmjs.org/babel-messages/-/babel-messages-6.23.0.tgz",
+      "integrity": "sha1-8830cDhYA1sqKVHG7F7fbGLyYw4="
+    },
+    "babel-runtime": {
+      "version": "6.23.0",
+      "resolved": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.23.0.tgz",
+      "integrity": "sha1-CpSJ8UTecO+zzkMArM2zKeL8VDs="
+    },
+    "babel-traverse": {
+      "version": "6.25.0",
+      "resolved": "https://registry.npmjs.org/babel-traverse/-/babel-traverse-6.25.0.tgz",
+      "integrity": "sha1-IldJfi/NGbie3BPEyROB+VEklvE="
+    },
+    "babel-types": {
+      "version": "6.25.0",
+      "resolved": "https://registry.npmjs.org/babel-types/-/babel-types-6.25.0.tgz",
+      "integrity": "sha1-cK+ySNVmDl0Y+BHZHIMDtUE0oY4="
+    },
+    "babylon": {
+      "version": "6.17.4",
+      "resolved": "https://registry.npmjs.org/babylon/-/babylon-6.17.4.tgz",
+      "integrity": "sha512-kChlV+0SXkjE0vUn9OZ7pBMWRFd8uq3mZe8x1K6jhuNcAFAtEnjchFAqB+dYEXKyd+JpT6eppRR78QAr5gTsUw=="
+    },
+    "balanced-match": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
+      "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c="
+    },
+    "brace-expansion": {
+      "version": "1.1.8",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.8.tgz",
+      "integrity": "sha1-wHshHHyVLsH479Uad+8NHTmQopI="
+    },
+    "builtin-modules": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/builtin-modules/-/builtin-modules-1.1.1.tgz",
+      "integrity": "sha1-Jw8HbFpywC9bZaR9+Uxf46J4iS8="
+    },
+    "camelcase": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-3.0.0.tgz",
+      "integrity": "sha1-MvxLn82vhF/N9+c7uXysImHwqwo="
+    },
+    "chalk": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+      "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg="
+    },
+    "cliui": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/cliui/-/cliui-3.2.0.tgz",
+      "integrity": "sha1-EgYBU3qRbSmUD5NNo7SNWFo5IT0="
+    },
+    "coa": {
+      "version": "0.3.9",
+      "resolved": "https://registry.npmjs.org/coa/-/coa-0.3.9.tgz",
+      "integrity": "sha1-fj0g0wr3C4CGLpXU1JtxUYO+lgQ="
+    },
+    "code-point-at": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz",
+      "integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c="
+    },
+    "commander": {
+      "version": "2.10.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-2.10.0.tgz",
+      "integrity": "sha512-q/r9trjmuikWDRJNTBHAVnWhuU6w+z80KgBq7j9YDclik5E7X4xi0KnlZBNFA1zOQ+SH/vHMWd2mC9QTOz7GpA=="
+    },
+    "concat-map": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+      "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s="
+    },
+    "core-js": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.4.1.tgz",
+      "integrity": "sha1-TekR5mew6ukSTjQlS1OupvxhjT4="
+    },
+    "debug": {
+      "version": "2.6.8",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.8.tgz",
+      "integrity": "sha1-5zFTHKLt4n0YgiJCfaF4IdaP9Pw="
+    },
+    "decamelize": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
+      "integrity": "sha1-9lNNFRSCabIDUue+4m9QH5oZEpA="
+    },
+    "deep-diff": {
+      "version": "0.3.8",
+      "resolved": "https://registry.npmjs.org/deep-diff/-/deep-diff-0.3.8.tgz",
+      "integrity": "sha1-wB3mPvsO7JeYgB1Ax+Da4ltYLIQ=",
+      "dev": true
+    },
+    "depcheck": {
+      "version": "0.6.7",
+      "resolved": "https://registry.npmjs.org/depcheck/-/depcheck-0.6.7.tgz",
+      "integrity": "sha1-az0emTkx4J7mc9NQfTF123NII+Y="
+    },
+    "deprecate": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/deprecate/-/deprecate-1.0.0.tgz",
+      "integrity": "sha1-ZhSQ7SQokWpsiIPYg05WRvTkpKg="
+    },
+    "deps-regex": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/deps-regex/-/deps-regex-0.1.4.tgz",
+      "integrity": "sha1-UYZnt2kUYKXn4KNBvnbrfOgJAYQ="
+    },
+    "error-ex": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/error-ex/-/error-ex-1.3.1.tgz",
+      "integrity": "sha1-+FWobOYa3E6GIcPNoh56dhLDqNw="
+    },
+    "escape-string-regexp": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+      "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ="
+    },
+    "esprima": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/esprima/-/esprima-3.1.3.tgz",
+      "integrity": "sha1-/cpRzuYTOJXjyI1TXOSdv/YqRjM="
+    },
+    "esutils": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz",
+      "integrity": "sha1-Cr9PHKpbyx96nYrMbepPqqBLrJs="
+    },
+    "find-up": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/find-up/-/find-up-1.1.2.tgz",
+      "integrity": "sha1-ay6YIrGizgpgq2TWEOzK1TyyTQ8="
+    },
+    "folktale": {
+      "version": "2.0.0-alpha4",
+      "resolved": "https://registry.npmjs.org/folktale/-/folktale-2.0.0-alpha4.tgz",
+      "integrity": "sha1-ouHY1dnV6dIwoAbv1GPDkYYSHsE="
+    },
+    "fs-extra": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-2.1.2.tgz",
+      "integrity": "sha1-BGxwFjzvmq1GsOSn+kZ/si1x3jU="
+    },
+    "fs.realpath": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
+      "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8="
+    },
+    "get-caller-file": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-1.0.2.tgz",
+      "integrity": "sha1-9wLmMSfn4jHBYKgMFVSstw1QR+U="
+    },
+    "glob": {
+      "version": "7.1.2",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
+      "integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ=="
+    },
+    "globals": {
+      "version": "9.18.0",
+      "resolved": "https://registry.npmjs.org/globals/-/globals-9.18.0.tgz",
+      "integrity": "sha512-S0nG3CLEQiY/ILxqtztTWH/3iRRdyBLw6KMDxnKMchrtbj2OFmehVh0WUCfW3DUrIgx/qFrJPICrq4Z4sTR9UQ=="
+    },
+    "graceful-fs": {
+      "version": "4.1.11",
+      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.11.tgz",
+      "integrity": "sha1-Dovf5NHduIVNZOBOp8AOKgJuVlg="
+    },
+    "graceful-readlink": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/graceful-readlink/-/graceful-readlink-1.0.1.tgz",
+      "integrity": "sha1-TK+tdrxi8C+gObL5Tpo906ORpyU="
+    },
+    "has-ansi": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
+      "integrity": "sha1-NPUEnOHs3ysGSa8+8k5F7TVBbZE="
+    },
+    "hosted-git-info": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.5.0.tgz",
+      "integrity": "sha512-pNgbURSuab90KbTqvRPsseaTxOJCZBD0a7t+haSN33piP9cCM4l0CqdzAif2hUqm716UovKB2ROmiabGAKVXyg=="
+    },
+    "inflight": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
+      "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk="
+    },
+    "inherits": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
+      "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4="
+    },
+    "invariant": {
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/invariant/-/invariant-2.2.2.tgz",
+      "integrity": "sha1-nh9WrArNtr8wMwbzOL47IErmA2A="
+    },
+    "invert-kv": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/invert-kv/-/invert-kv-1.0.0.tgz",
+      "integrity": "sha1-EEqOSqym09jNFXqO+L+rLXo//bY="
+    },
+    "is-arrayish": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz",
+      "integrity": "sha1-d8mYQFJ6qOyxqLppe4BkWnqSap0="
+    },
+    "is-builtin-module": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/is-builtin-module/-/is-builtin-module-1.0.0.tgz",
+      "integrity": "sha1-VAVy0096wxGfj3bDDLwbHgN6/74="
+    },
+    "is-fullwidth-code-point": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
+      "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs="
+    },
+    "is-utf8": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/is-utf8/-/is-utf8-0.2.1.tgz",
+      "integrity": "sha1-Sw2hRCEE0bM2NA6AeX6GXPOffXI="
+    },
+    "js-tokens": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-3.0.2.tgz",
+      "integrity": "sha1-mGbfOVECEw449/mWvOtlRDIJwls="
+    },
+    "js-yaml": {
+      "version": "3.8.4",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.8.4.tgz",
+      "integrity": "sha1-UgtFZPhlc7qWZir4Woyvp7S1pvY="
+    },
+    "jsonfile": {
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-2.4.0.tgz",
+      "integrity": "sha1-NzaitCi4e72gzIO1P6PWM6NcKug="
+    },
+    "lcid": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/lcid/-/lcid-1.0.0.tgz",
+      "integrity": "sha1-MIrMr6C8SDo4Z7S28rlQYlHRuDU="
+    },
+    "load-json-file": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-1.1.0.tgz",
+      "integrity": "sha1-lWkFcI1YtLq0wiYbBPWfMcmTdMA="
+    },
+    "lodash": {
+      "version": "4.17.4",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.4.tgz",
+      "integrity": "sha1-eCA6TRwyiuHYbcpkYONptX9AVa4="
+    },
+    "loose-envify": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.3.1.tgz",
+      "integrity": "sha1-0aitM/qc4OcT1l/dCsi3SNR4yEg="
+    },
+    "minimatch": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
+      "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA=="
+    },
+    "minimist": {
+      "version": "0.0.8",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
+      "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0="
+    },
+    "mkdirp": {
+      "version": "0.5.1",
+      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
+      "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM="
+    },
+    "moment": {
+      "version": "2.18.1",
+      "resolved": "https://registry.npmjs.org/moment/-/moment-2.18.1.tgz",
+      "integrity": "sha1-w2GT3Tzhwu7SrbfIAtu8d6gbHA8="
+    },
+    "ms": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+      "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
+    },
+    "normalize-package-data": {
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-2.4.0.tgz",
+      "integrity": "sha512-9jjUFbTPfEy3R/ad/2oNbKtW9Hgovl5O1FvFWKkKblNXoN/Oou6+9+KKohPK13Yc3/TyunyWhJp6gvRNR/PPAw=="
+    },
+    "number-is-nan": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz",
+      "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0="
+    },
+    "ometajs": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/ometajs/-/ometajs-4.0.0.tgz",
+      "integrity": "sha1-e/vSeO8O9c76XQUGLdeHus7VbLU="
+    },
+    "once": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+      "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E="
+    },
+    "os-locale": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/os-locale/-/os-locale-1.4.0.tgz",
+      "integrity": "sha1-IPnxeuKe00XoveWDsT0gCYA8FNk="
+    },
+    "parse-json": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-2.2.0.tgz",
+      "integrity": "sha1-9ID0BDTvgHQfhGkJn43qGPVaTck="
+    },
+    "path-exists": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-2.1.0.tgz",
+      "integrity": "sha1-D+tsZPD8UY2adU3V77YscCJ2H0s="
+    },
+    "path-is-absolute": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+      "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18="
+    },
+    "path-type": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/path-type/-/path-type-1.1.0.tgz",
+      "integrity": "sha1-WcRPfuSR2nBNpBXaWkBwuk+P5EE="
+    },
+    "pify": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
+      "integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw="
+    },
+    "pinkie": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/pinkie/-/pinkie-2.0.4.tgz",
+      "integrity": "sha1-clVrgM+g1IqXToDnckjoDtT3+HA="
+    },
+    "pinkie-promise": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.1.tgz",
+      "integrity": "sha1-ITXW36ejWMBprJsXh3YogihFD/o="
+    },
+    "q": {
+      "version": "0.8.12",
+      "resolved": "https://registry.npmjs.org/q/-/q-0.8.12.tgz",
+      "integrity": "sha1-kWKpHhGBnEvNp9oVz1/vqtB3iCM="
+    },
+    "read-pkg": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-1.1.0.tgz",
+      "integrity": "sha1-9f+qXs0pyzHAR0vKfXVra7KePyg="
+    },
+    "read-pkg-up": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-1.0.1.tgz",
+      "integrity": "sha1-nWPBMnbAZZGNV/ACpX9AobZD+wI="
+    },
+    "regenerator-runtime": {
+      "version": "0.10.5",
+      "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.10.5.tgz",
+      "integrity": "sha1-M2w+/BIgrc7dosn6tntaeVWjNlg="
+    },
+    "require-directory": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
+      "integrity": "sha1-jGStX9MNqxyXbiNE/+f3kqam30I="
+    },
+    "require-main-filename": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/require-main-filename/-/require-main-filename-1.0.1.tgz",
+      "integrity": "sha1-l/cXtp1IeE9fUmpsWqj/3aBVpNE="
+    },
+    "require-package-name": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/require-package-name/-/require-package-name-2.0.1.tgz",
+      "integrity": "sha1-wR6XJ2tluOKSP3Xav1+y7ww4Qbk="
+    },
+    "rimraf": {
+      "version": "2.6.1",
+      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.1.tgz",
+      "integrity": "sha1-wjOOxkPfeht/5cVPqG9XQopV8z0="
+    },
+    "semver": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-5.3.0.tgz",
+      "integrity": "sha1-myzl094C0XxgEq0yaqa00M9U+U8="
+    },
+    "set-blocking": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
+      "integrity": "sha1-BF+XgtARrppoA93TgrJDkrPYkPc="
+    },
+    "spdx-correct": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/spdx-correct/-/spdx-correct-1.0.2.tgz",
+      "integrity": "sha1-SzBz2TP/UfORLwOsVRlJikFQ20A="
+    },
+    "spdx-expression-parse": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/spdx-expression-parse/-/spdx-expression-parse-1.0.4.tgz",
+      "integrity": "sha1-m98vIOH0DtRH++JzJmGR/O1RYmw="
+    },
+    "spdx-license-ids": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-1.2.2.tgz",
+      "integrity": "sha1-yd96NCRZSt5r0RkA1ZZpbcBrrFc="
+    },
+    "sprintf-js": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
+      "integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw="
+    },
+    "string-width": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
+      "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M="
+    },
+    "strip-ansi": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+      "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8="
+    },
+    "strip-bom": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-2.0.0.tgz",
+      "integrity": "sha1-YhmoVhZSBJHzV4i9vxRHqZx+aw4="
+    },
+    "supports-color": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
+      "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc="
+    },
+    "to-fast-properties": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-1.0.3.tgz",
+      "integrity": "sha1-uDVx+k2MJbguIxsG46MFXeTKGkc="
+    },
+    "uglify-js": {
+      "version": "1.3.5",
+      "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-1.3.5.tgz",
+      "integrity": "sha1-S1v/+Rhu/7qoiOTJ6UvZ/EyUkp0="
+    },
+    "validate-npm-package-license": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/validate-npm-package-license/-/validate-npm-package-license-3.0.1.tgz",
+      "integrity": "sha1-KAS6vnEq0zeUWaz74kdGqywwP7w="
+    },
+    "walkdir": {
+      "version": "0.0.11",
+      "resolved": "https://registry.npmjs.org/walkdir/-/walkdir-0.0.11.tgz",
+      "integrity": "sha1-oW0CXrkxvQO1LzCMrtD0D86+lTI="
+    },
+    "which-module": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/which-module/-/which-module-1.0.0.tgz",
+      "integrity": "sha1-u6Y8qGGUiZT/MHc2CJ47lgJsKk8="
+    },
+    "wrap-ansi": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-2.1.0.tgz",
+      "integrity": "sha1-2Pw9KE3QV5T+hJc8rs3Rz4JP3YU="
+    },
+    "wrappy": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+      "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8="
+    },
+    "xtend": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz",
+      "integrity": "sha1-pcbVMr5lbiPbgg77lDofBJmNY68="
+    },
+    "y18n": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/y18n/-/y18n-3.2.1.tgz",
+      "integrity": "sha1-bRX7qITAhnnA136I53WegR4H+kE="
+    },
+    "yargs": {
+      "version": "6.6.0",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-6.6.0.tgz",
+      "integrity": "sha1-eC7CHvQDNF+DCoCMo9UTr1YGUgg="
+    },
+    "yargs-parser": {
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-4.2.1.tgz",
+      "integrity": "sha1-KczqwNxPA8bIe0qfIX3RjJ90hxw="
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "chalk": "^1.1.3",
     "commander": "^2.9.0",
     "depcheck": "^0.6.7",
-    "folktale": "^2.0.0-alpha4",
+    "folktale": "2.0.0-alpha4",
     "fs-extra": "^2.1.2",
     "glob": "^7.1.1",
     "mkdirp": "^0.5.1",

--- a/source/vm/ast.js
+++ b/source/vm/ast.js
@@ -19,6 +19,10 @@ const AST = data('furipota:ast', {
     return { name };
   },
 
+  Hole() {
+    return { };
+  },
+
   Keyword(name) {
     return { name };
   },
@@ -99,10 +103,6 @@ const AST = data('furipota:ast', {
   // --[ Expressions ]--------------------------------------------------
   Invoke(callee, input, options) {
     return { callee, input, options };
-  },
-
-  Partial(callee, options) {
-    return { callee, options };
   },
 
   Pipe(input, transformation) {

--- a/source/vm/core-library/core.js
+++ b/source/vm/core-library/core.js
@@ -8,9 +8,14 @@
 //----------------------------------------------------------------------
 
 module.exports = (furipota) => {
-  const { nativeModule, native, tagged } = furipota.primitives;
+  const { nativeModule, native, nativeThunk, tagged, unit } = furipota.primitives;
 
   return nativeModule('core:core', {
+    unit:
+    nativeThunk('unit', 'Represents the no value', 
+      (ctx) => unit
+    ),
+
     match:
     native('match', [['Any'], {_: 'Invokable'}],
       'matches a tagged value to its appropriate handler',

--- a/source/vm/core-library/record.js
+++ b/source/vm/core-library/record.js
@@ -43,6 +43,12 @@ module.exports = (furipota) => {
     'empty':
     nativeThunk('empty', 'Constructs an empty record',
       (ctx) => ({})
+    ),
+
+    'keys':
+    native('keys', [['Record'], {}],
+      'Returns the keys present in a record as a vector',
+      (ctx, record, _options) => Object.keys(record)
     )
   });
 };

--- a/source/vm/evaluator.js
+++ b/source/vm/evaluator.js
@@ -112,6 +112,10 @@ function evaluate(ast, originalContext) {
     Identifier: ({ name }) =>
       name,
 
+    Hole: () => {
+      ctx.assert(false, `Application hole not removed during desugaring phase. This is probably an error in the FuriPota VM.`);
+    },
+
     Keyword: ({ name }) =>
       name,
 
@@ -224,37 +228,6 @@ function evaluate(ast, originalContext) {
       ctx.traceExpression(callee).assertType('Invokable', fn);
 
       return fn.invoke(ctx, inputValue, optionsValue);
-    },
-
-    Prefix: ({ operator, expression }) => {
-      const fn = evaluate(operator, ctx);
-      const exprValue = evaluate(expression, ctx);
-      ctx.traceExpression(operator).assertType('Invokable', fn);
-
-      return fn.invoke(ctx, exprValue, {});
-    },
-
-    Infix: ({ operator, left, right }) => {
-      const fn = evaluate(operator, ctx);
-      const leftValue = evaluate(left, ctx);
-      const rightValue = evaluate(right, ctx);
-      ctx.traceExpression(operator).assertType('Invokable', fn);
-
-      const fn2 = fn.invoke(ctx, rightValue, {});
-      ctx.assertType('Invokable', fn2);
-
-      return fn2.invoke(ctx, leftValue, {});
-    },
-
-    Partial: ({ callee, options }) => {
-      const calleeValue = evaluate(callee, ctx);
-      ctx.traceExpression(callee).assertType('Invokable', calleeValue);
-
-      return new Partial(
-        ctx,
-        calleeValue,
-        evaluate(options, ctx)
-      );
     },
 
     Pipe: ({ input, transformation }) => {

--- a/source/vm/parser.ometajs
+++ b/source/vm/parser.ometajs
@@ -78,6 +78,8 @@ ometa FuripotaParser {
   infix = (seq('===') | seq('=/=') | '>' | seq('>=') | seq('<') | seq('<=') | '+' | '-' | '*' | '/'):a
           -> ast.Identifier(a),
 
+  Hole = '_' -> ast.Hole(),
+
 
   // --[ Values ]
   value = Boolean | Number | Text | Vector | Record | Lambda | Tagged,
@@ -234,8 +236,6 @@ ometa FuripotaParser {
 
   Invoke = Invoke:i ws memberExpression:v (ws '@' ws Record)?:r
            -> ast.Invoke(i, v, r || ast.Record([]))
-         | Invoke:i ws '_' (ws '@' ws Record)?:r
-           -> ast.Partial(i, r || ast.Record([]))
          | memberExpression,
 
   memberExpression = memberExpression:m ws '.' ws Identifier:i
@@ -257,6 +257,7 @@ ometa FuripotaParser {
                    | Vector
                    | Tagged
                    | Shell
+                   | Hole
                    | Identifier:i               -> ast.Variable(i)
                    | '(' ws expression:a ws ')' -> a,
 

--- a/source/vm/parser.ometajs
+++ b/source/vm/parser.ometajs
@@ -219,15 +219,15 @@ ometa FuripotaParser {
                         -> ast.Get(a, ast.Identifier(i)),
 
   Relational = Relational:a ws (seq('===') | seq('=/=') | '>' | seq('>=') | '<' | seq('<=')):o ws Add:b
-               -> ast.Infix(ast.Variable(ast.Identifier(o)), b, a)
+               -> ast.Infix(ast.Variable(ast.Identifier(o)), a, b)
              | Add,
   
   Add = Add:a ws ('+' | '-'):o ws Multiply:b
-        -> ast.Infix(ast.Variable(ast.Identifier(o)), b, a)
+        -> ast.Infix(ast.Variable(ast.Identifier(o)), a, b)
       | Multiply,
 
   Multiply = Multiply:a ws ('*' | '/'):o sws Unary:b
-             -> ast.Infix(ast.Variable(ast.Identifier(o)), b, a)
+             -> ast.Infix(ast.Variable(ast.Identifier(o)), a, b)
            | Unary,
 
   Unary = kw('not') ws Invoke:e

--- a/source/vm/passes/desugar-application.js
+++ b/source/vm/passes/desugar-application.js
@@ -114,7 +114,7 @@ const desugarApplication = (node) =>
       ),
 
     Prefix: ({ operator, expression }) =>
-      ast.Invoke(operator, desugarApplication(expression)),
+      ast.Invoke(operator, desugarApplication(expression), ast.Record([])),
 
     Shell: ({ command, args, options }) =>
       ast.Shell(desugarApplication(command), args.map(desugarApplication), desugarApplication(options)),

--- a/source/vm/passes/desugar-application.js
+++ b/source/vm/passes/desugar-application.js
@@ -141,7 +141,7 @@ const desugarApplication = (node) =>
       ast.DoReturn(desugarApplication(expression)),
 
     DoBind: ({ id, expression }) =>
-      ast.DoBind(desugarApplication(id, expression)),
+      ast.DoBind(id, desugarApplication(expression)),
 
     DoLet: ({ id, expression }) =>
       ast.DoLet(id, expression),

--- a/source/vm/passes/desugar-application.js
+++ b/source/vm/passes/desugar-application.js
@@ -1,0 +1,161 @@
+//----------------------------------------------------------------------
+//
+// This source file is part of the furipota project.
+//
+// Licensed under MIT. See LICENCE for full licence information.
+// See CONTRIBUTORS for the list of contributors to the project.
+//
+//----------------------------------------------------------------------
+
+const ast = require('../ast');
+
+
+const desugarApplication = (node) =>
+  node.matchWith({
+    Seq: ({ items }) =>
+      ast.Seq(items.map(desugarApplication)),
+
+    Identifier: ({ name }) =>
+      ast.Identifier(name),
+
+    Hole: () =>
+      ast.Hole(),
+
+    Keyword: ({ name }) =>
+      ast.Keyword(name),
+
+    Text: ({ value }) =>
+      ast.Text(value),
+
+    Character: ({ character }) =>
+      ast.Character(character),
+
+    InterpolateExpression: ({ expression }) =>
+      ast.InterpolateExpression(desugarApplication(expression)),
+
+    Interpolate: ({ items }) =>
+      ast.Interpolate(items.map(desugarApplication)),
+
+    Integer: ({ sign, value }) =>
+      ast.Integer(sign, value),
+
+    Decimal: ({ sign, integral, decimal, exponent }) =>
+      ast.Decimal(sign, integral, decimal, exponent),
+
+    Boolean: ({ value }) =>
+      ast.Boolean(value),
+
+    Vector: ({ items }) =>
+      ast.Vector(items.map(desugarApplication)),
+
+    VectorSpread: ({ expression }) =>
+      ast.VectorSpread(desugarApplication(expression)),
+
+    VectorElement: ({ expression }) =>
+      ast.VectorElement(desugarApplication(expression)),
+
+    Record: ({ pairs }) =>
+      ast.Record(
+        pairs.map(([k, v]) => [k, desugarApplication(v)])
+      ),
+
+    Lambda: ({ value, options, expression }) =>
+      ast.Lambda(value, options, desugarApplication(expression)),
+
+    Tagged: ({ tag, value }) =>
+      ast.Tagged(tag, desugarApplication(value)),
+
+    Define: ({ id, expression, documentation }) =>
+      ast.Define(id, desugarApplication(expression), documentation),
+
+    Import: ({ path, kind }) =>
+      ast.Import(path, kind),
+
+    ImportAliasing: ({ path, alias, kind }) =>
+      ast.ImportAliasing(path, alias, kind),
+
+    Export: ({ identifier }) =>
+      ast.Export(identifier),
+
+    ExportAliasing: ({ identifier, alias }) =>
+      ast.ExportAliasing(identifier, alias),
+
+    Invoke: ({ callee, input, options }) =>
+      ast.Invoke(desugarApplication(callee), desugarApplication(input), desugarApplication(options)),
+
+    Pipe: ({ input, transformation }) =>
+      ast.Pipe(desugarApplication(input), desugarApplication(transformation)),
+
+    Variable: ({ id }) =>
+      ast.Variable(id),
+
+    Let: ({ binding, value, expression }) =>
+      ast.Let(binding, desugarApplication(value), desugarApplication(expression)),
+
+    IfThenElse: ({ condition, consequent, alternate }) =>
+      ast.IfThenElse(
+        desugarApplication(condition),
+        desugarApplication(consequent),
+        desugarApplication(alternate)
+      ),
+
+    Get: ({ expression, property }) =>
+      ast.Get(desugarApplication(expression), property),
+
+    Infix: ({ operator, left, right }) =>
+      ast.Invoke(
+        ast.Invoke(
+          operator,
+          desugarApplication(left),
+          ast.Record([])
+        ),
+        desugarApplication(right),
+        ast.Record([])
+      ),
+
+    Prefix: ({ operator, expression }) =>
+      ast.Invoke(operator, desugarApplication(expression)),
+
+    Shell: ({ command, args, options }) =>
+      ast.Shell(desugarApplication(command), args.map(desugarApplication), desugarApplication(options)),
+
+    ShellSymbol: ({ symbol }) =>
+      ast.ShellSymbol(symbol),
+
+    ShellSpread: ({ items }) =>
+      ast.ShellSpread(items.map(desugarApplication)),
+
+    ShellExpression: ({ expression }) =>
+      ast.ShellExpression(desugarApplication(expression)),
+
+    Do: ({ instructions }) =>
+      ast.Do(instructions.map(desugarApplication)),
+
+    DoCall: ({ expression }) =>
+      ast.DoCall(desugarApplication(expression)),
+
+    DoAction: ({ expression }) =>
+      ast.DoAction(desugarApplication(expression)),
+
+    DoReturn: ({ expression }) =>
+      ast.DoReturn(desugarApplication(expression)),
+
+    DoBind: ({ id, expression }) =>
+      ast.DoBind(desugarApplication(id, expression)),
+
+    DoLet: ({ id, expression }) =>
+      ast.DoLet(id, expression),
+
+    DoIfThenElse: ({ condition, consequent, alternate }) =>
+      ast.DoIfThenElse(
+        desugarApplication(condition),
+        desugarApplication(consequent),
+        desugarApplication(alternate)
+      ),
+
+    Program: ({ declarations }) =>
+      ast.Program(declarations.map(desugarApplication))
+  });
+
+
+module.exports = desugarApplication;

--- a/source/vm/passes/desugar-holes.js
+++ b/source/vm/passes/desugar-holes.js
@@ -60,7 +60,7 @@ const collectOptionHoles = (bindings, options) => {
 
   const [holes, pairs] = options.pairs.reduce(
     ([holes, pairs], [key, value]) => {
-      const [newHoles, newValue] = collectHole(value);
+      const [newHoles, newValue] = collectHole(bindings, value);
       return [
         [...holes, ...newHoles], 
         [...pairs, [key, newValue]]

--- a/source/vm/passes/desugar-holes.js
+++ b/source/vm/passes/desugar-holes.js
@@ -1,0 +1,274 @@
+//----------------------------------------------------------------------
+//
+// This source file is part of the furipota project.
+//
+// Licensed under MIT. See LICENCE for full licence information.
+// See CONTRIBUTORS for the list of contributors to the project.
+//
+//----------------------------------------------------------------------
+
+const ast = require('../ast');
+
+
+class BindingBox {
+  constructor() {
+    this.count = 0;
+  }
+
+  fresh() {
+    return `$${++this.count}`;
+  }
+}
+
+
+const makeLambda = (args, recordArg, expr) => {
+  const lastArg = args[args.length - 1];
+  return args.slice(0, -1).reduceRight((fn, arg) => {
+    return ast.Lambda(arg, ast.Identifier('_'), fn);
+  }, ast.Lambda(lastArg, recordArg, expr))
+};
+
+
+const collectInvokeHoles = (bindings, node) => {
+  if (!ast.Invoke.hasInstance(node)) {
+    throw new SyntaxError(`Expected an Invoke node, got ${node}`);
+  }
+
+  const [choles, callee] = collectImmediateHoles(bindings, node.callee);
+  const [iholes, input] = collectHole(bindings, node.input);
+  const [oholes, options] = collectOptionHoles(bindings, node.options);
+  const holes = [...choles, ...iholes, ...oholes];
+
+  return [holes, ast.Invoke(callee, input, options)];
+};
+
+
+const collectHole = (bindings, input) => {
+  if (ast.Hole.hasInstance(input)) {
+    const name = bindings.fresh();
+    return [[name], ast.Variable(ast.Identifier(name))];
+  } else {
+    return [[], desugarHoles(bindings, input)];
+  }
+};
+
+
+const collectOptionHoles = (bindings, options) => {
+  if (!ast.Record.hasInstance(options)) {
+    throw new SyntaxError(`Expected a record for options, got ${options}`);
+  }
+
+  const [holes, pairs] = options.pairs.reduce(
+    ([holes, pairs], [key, value]) => {
+      const [newHoles, newValue] = collectHole(value);
+      return [
+        [...holes, ...newHoles], 
+        [...pairs, [key, newValue]]
+      ];
+    },
+    [[], []]
+  );
+
+  return [holes, ast.Record(pairs)];
+};
+
+
+const collectImmediateHoles = (bindings, node) => {
+  if (ast.Invoke.hasInstance(node)) {
+    return collectInvokeHoles(bindings, node);
+  } else {
+    return collectHole(bindings, node);
+  }
+};
+
+
+const maybeSimplifyInvokeHoles = (bindings, node) => {
+  const [holes, newNode] = collectInvokeHoles(bindings, node);
+
+  if (holes.length > 0) {
+    return makeLambda(
+      holes.map(ast.Identifier),
+      ast.Identifier('_'),
+      newNode
+    );
+  } else {
+    return newNode;
+  }
+};
+
+
+const collectPipeHoles = (bindings, node) => {
+  const [holes, newTransformation] = collectImmediateHoles(bindings, node.transformation);
+  return [holes, ast.Pipe(desugarHoles(bindings, node.input), newTransformation)];
+};
+
+
+const maybeSimplifyPipeHoles = (bindings, node) => {
+  const [holes, newNode] = collectPipeHoles(bindings, node);
+
+  if (holes.length > 0) {
+    return ast.Pipe(
+      newNode.input,
+      makeLambda(
+        holes.map(ast.Identifier),
+        ast.Identifier('_'),
+        newNode.transformation
+      )
+    );
+  } else {
+    return newNode;
+  }
+};
+
+
+
+const desugarHoles = (bindings, node) =>
+  node.matchWith({
+    Seq: ({ items }) =>
+      ast.Seq(items.map(x => desugarHoles(bindings, x))),
+
+    Identifier: ({ name }) =>
+      ast.Identifier(name),
+
+    Hole: () => {
+      throw new SyntaxError(`Holes are only allowed in function applications.`);
+    },
+
+    Keyword: ({ name }) =>
+      ast.Keyword(name),
+
+    Text: ({ value }) =>
+      ast.Text(value),
+
+    Character: ({ character }) =>
+      ast.Character(character),
+
+    InterpolateExpression: ({ expression }) =>
+      ast.InterpolateExpression(desugarHoles(bindings, expression)),
+
+    Interpolate: ({ items }) =>
+      ast.Interpolate(items.map(x => desugarHoles(bindings, x))),
+
+    Integer: ({ sign, value }) =>
+      ast.Integer(sign, value),
+
+    Decimal: ({ sign, integral, decimal, exponent }) =>
+      ast.Decimal(sign, integral, decimal, exponent),
+
+    Boolean: ({ value }) =>
+      ast.Boolean(value),
+
+    Vector: ({ items }) =>
+      ast.Vector(items.map(x => desugarHoles(bindings, x))),
+
+    VectorSpread: ({ expression }) =>
+      ast.VectorSpread(desugarHoles(bindings, expression)),
+
+    VectorElement: ({ expression }) =>
+      ast.VectorElement(desugarHoles(bindings, expression)),
+
+    Record: ({ pairs }) =>
+      ast.Record(
+        pairs.map(([k, v]) => 
+          [k, desugarHoles(bindings, v)]
+        )
+      ),
+
+    Lambda: ({ value, options, expression }) =>
+      ast.Lambda(value, options, desugarHoles(bindings, expression)),
+
+    Tagged: ({ tag, value }) =>
+      ast.Tagged(tag, desugarHoles(bindings, value)),
+
+    Define: ({ id, expression, documentation }) =>
+      ast.Define(id, desugarHoles(bindings, expression), documentation),
+
+    Import: ({ path, kind }) =>
+      ast.Import(path, kind),
+
+    ImportAliasing: ({ path, alias, kind }) =>
+      ast.ImportAliasing(path, alias, kind),
+
+    Export: ({ identifier }) =>
+      ast.Export(identifier),
+
+    ExportAliasing: ({ identifier, alias }) =>
+      ast.ExportAliasing(identifier, alias),
+
+    Invoke: ({ callee, input, options }) =>
+      maybeSimplifyInvokeHoles(bindings, ast.Invoke(callee, input, options)),
+
+    Pipe: ({ input, transformation }) =>
+      maybeSimplifyPipeHoles(bindings, ast.Pipe(input, transformation)),
+
+    Variable: ({ id }) =>
+      ast.Variable(id),
+
+    Let: ({ binding, value, expression }) =>
+      ast.Let(binding, desugarHoles(bindings, value), desugarHoles(bindings, expression)),
+
+    IfThenElse: ({ condition, consequent, alternate }) =>
+      ast.IfThenElse(
+        desugarHoles(bindings, condition),
+        desugarHoles(bindings, consequent),
+        desugarHoles(bindings, alternate)
+      ),
+
+    Get: ({ expression, property }) =>
+      ast.Get(desugarHoles(bindings, expression), property),
+
+    Infix: ({ operator, left, right }) => {
+      throw new SyntaxError(`Infix node found while desugaring holes, after desugaring applications. This is probably an error in the Furipota compiler.`);
+    },
+
+    Prefix: ({ operator, expression }) => {
+      throw new SyntaxError(`Prefix node found while desugaring holes, after desugaring applications. This is probably an error in the Furipota compiler.`)
+    },
+
+    Shell: ({ command, args, options }) =>
+      ast.Shell(
+        desugarHoles(bindings, command), 
+        args.map(x => desugarHoles(bindings, x)), 
+        desugarHoles(bindings, options)
+      ),
+
+    ShellSymbol: ({ symbol }) =>
+      ast.ShellSymbol(symbol),
+
+    ShellSpread: ({ items }) =>
+      ast.ShellSpread(items.map(x => desugarHoles(bindings, x))),
+
+    ShellExpression: ({ expression }) =>
+      ast.ShellExpression(desugarHoles(bindings, expression)),
+
+    Do: ({ instructions }) =>
+      ast.Do(instructions.map(x => desugarHoles(bindings, x))),
+
+    DoCall: ({ expression }) =>
+      ast.DoCall(desugarHoles(bindings, expression)),
+
+    DoAction: ({ expression }) =>
+      ast.DoAction(desugarHoles(bindings, expression)),
+
+    DoReturn: ({ expression }) =>
+      ast.DoReturn(desugarHoles(bindings, expression)),
+
+    DoBind: ({ id, expression }) =>
+      ast.DoBind(id, desugarHoles(bindings, expression)),
+
+    DoLet: ({ id, expression }) =>
+      ast.DoLet(id, desugarHoles(bindings, expression)),
+
+    DoIfThenElse: ({ condition, consequent, alterenate }) =>
+      ast.DoIfThenElse(
+        desugarHoles(bindings, condition),
+        desugarHoles(bindings, consequent),
+        desugarHoles(bindings, alternate)
+      ),
+
+    Program: ({ declarations }) =>
+      ast.Program(declarations.map(x => desugarHoles(bindings, x)))
+  });
+
+
+module.exports = (node) => desugarHoles(new BindingBox(), node);

--- a/source/vm/passes/index.js
+++ b/source/vm/passes/index.js
@@ -1,0 +1,21 @@
+//----------------------------------------------------------------------
+//
+// This source file is part of the furipota project.
+//
+// Licensed under MIT. See LICENCE for full licence information.
+// See CONTRIBUTORS for the list of contributors to the project.
+//
+//----------------------------------------------------------------------
+
+const desugarHoles = require('./desugar-holes');
+const desugarApplication = require('./desugar-application');
+const compose = require('folktale/core/lambda/compose');
+
+
+const compile = compose(
+  desugarHoles,
+  desugarApplication
+);
+
+
+module.exports = compile;

--- a/source/vm/pretty-print.js
+++ b/source/vm/pretty-print.js
@@ -13,7 +13,7 @@ const needsParenthesis = (ast) =>
   ![
     AST.Identifier, AST.Keyword, AST.Text, AST.Integer, AST.Decimal, 
     AST.Boolean, AST.Record, AST.Vector, AST.Variable, AST.Shell,
-    AST.Get
+    AST.Get, AST.Hole
   ].some(
     x => x.hasInstance(ast)
   );
@@ -32,6 +32,10 @@ const prettyPrint = (node, depth = 0) => {
 
     Identifier: ({ name }) => {
       return name;
+    },
+
+    Hole: () => {
+      return '_';
     },
 
     Keyword: ({ name }) => {
@@ -112,10 +116,6 @@ const prettyPrint = (node, depth = 0) => {
 
     Invoke: ({ callee, input, options }) => {
       return p(callee, depth) + ' ' + p(input, depth) + ' ' + prettyPrint(options, depth); 
-    },
-
-    Partial: ({ callee, options }) => {
-      return p(callee, depth) + ' _ ' + prettyPrint(options, depth);
     },
 
     Pipe: ({ input, transformation }) => {

--- a/source/vm/primitives.js
+++ b/source/vm/primitives.js
@@ -76,7 +76,7 @@ function show(ctx, x) {
     'Boolean': (x) => String(x),
     'Number':  (x) => String(x),
     'Text':    (x) => x,
-    'Vector':  (x) => `[${x.map(show).join(', ')}]`,
+    'Vector':  (x) => `[${x.map((v) => show(ctx, v)).join(', ')}]`,
     '^Path':   (x) => pathToText(x),
     '^Shell-stderr':    (x) => x.value,
     '^Shell-error':     (x) => x.value.stack,

--- a/source/vm/vm.js
+++ b/source/vm/vm.js
@@ -20,6 +20,7 @@ const AST = require('./ast');
 const Parser = require('./parser').FuripotaParser;
 const CoreModules = require('./core-library');
 const Plugins = require('./plugins');
+const compile = require('./passes');
 
 
 function readAsText(path) {
@@ -53,7 +54,7 @@ class FuripotaVM {
   }
 
   evaluate(ast, context) {
-    return evaluate(ast, context);
+    return evaluate(compile(ast), context);
   }
 
   loadModule(file, kind) {


### PR DESCRIPTION
This allows users to partially apply functions by just placing holes
where missing parameters should be filled in later. Partial
application in this way constructs a new lambda.

For example:

    add _ 2

Is desugared into:

    (x -> add x 2)

Multi-parameter and infix applications work as expected:

    f _ 2 _
    1 + _

Gets translated to:

    (x1 -> x2 -> f x1 2 x2)
    (x -> 1 + x)

Binding generation is more on the functional than the pretty side.

Aside from applications, pipes can also use holes:

    a |> b _ c

Gets desugared into:

    a |> (x -> b x c)

Holes only affect *immediate* applications. That is, a hole only
contributes as partial application to the immediate invocation
surrounding it. Thus:

    f _ (2 + _)

Gets desugared to:

    (x -> f x (y -> 2 + y))

**NOT**:

    (x1 -> x2 -> f x1 (2 + x2))

Things are a tiny bit more complex on the definition of "immediate invocation"
since Furipota is a curried language. For prefix (non-operator) applications
we consider subsequent applications with the same fixity and precedence. That
is:

    ((f _) _) 2

Gets desugared into:

    (x1 -> x2 -> ((f x1) x2) 2)

But:

    (f (g _) 2)

Gets desugared into:

    (f (x -> g x) 2)
