### PR TITLE
Unique open variants and pattern matching

### DIFF
--- a/build.frp
+++ b/build.frp
@@ -60,10 +60,9 @@ export define build =
 
 export define test =
   # Runs the tests for Furipota VM
-  let show-error e = match e @ 
-        -Shell-error e     -> e.stack
-        -Shell-exit-code e -> "The program exited with code {e}"
-        -Shell-stderr e    -> e
+  let show-error e = match e with
+    case ^Shell.Error e     then e.stack
+    case ^Shell.Exit-Code c then "The program exited with code {e}"
   in do
     bind test <- find (path "tests/**/run.js")
     action Debug.log (Path.to-text (Path.directory test)) @ -prefix: "TEST"

--- a/docs/language-overview.md
+++ b/docs/language-overview.md
@@ -149,8 +149,8 @@ Furipota does not have classes or [tagged unions](https://en.wikipedia.org/wiki/
 You create tags with the `^Tag predicates…` syntax, where a predicate is any function that returns `true` if the value at that position is valid, or `false` otherwise:
 
 ```ruby
-define any x = true
-define Tuple2 = ^Tuple2 any any
+define is-any x = true
+define Tuple2 = ^Tuple2 is-any is-any
 ```
 
 You construct tagged values by using the `make` function from the core library:
@@ -166,7 +166,7 @@ And you extract values with the `match...with` syntax, and the `^Tag` pattern. N
 ```ruby
 match one-two with
   case ^Tuple2 (let first) (let second) then first + second
-  case ^((x -> x) Tuple2) _ _ then "same as above"
+  case ^((x -> x) Tuple2) any any then "same as above"
   default "nothing matched."
 ```
 

--- a/docs/language-overview.md
+++ b/docs/language-overview.md
@@ -146,17 +146,28 @@ if 2 < 3 then "less than" else "greater than"
 
 Furipota does not have classes or [tagged unions](https://en.wikipedia.org/wiki/Tagged_union), instead it uses the simpler concept of [open variants](https://caml.inria.fr/pub/docs/u3-ocaml/ocaml051.html). In Furipota in particular, an open variant is just a *tagged* value: a value and its associated "type identifier".
 
-You put values into tags with the `^Tag value` syntax:
+You create tags with the `^Tag predicates…` syntax, where a predicate is any function that returns `true` if the value at that position is valid, or `false` otherwise:
 
 ```ruby
-define one = ^Int 1
+define any x = true
+define Tuple2 = ^Tuple2 any any
 ```
 
-And you extract values from tags with the `match` function:
+You construct tagged values by using the `make` function from the core library:
 
 ```ruby
-match one
-  -Int value: (value + 1)
+import core "core"
+
+define one-two = make Tuple2 [1, 2]
+```
+
+And you extract values with the `match...with` syntax, and the `^Tag` pattern. Note that the `Tag` here is an expression that returns a tag, not an arbitrary identifier:
+
+```ruby
+match one-two with
+  case ^Tuple2 (let first) (let second) then first + second
+  case ^((x -> x) Tuple2) _ _ then "same as above"
+  default "nothing matched."
 ```
 
 ## Modules and definitions

--- a/source/vm/ast.js
+++ b/source/vm/ast.js
@@ -75,8 +75,45 @@ const AST = union('furipota:ast', {
     return { value, options, expression };
   },
 
-  Tagged(tag, value) {
-    return { tag, value };
+  Tagged(tag, predicates) {
+    return { tag, predicates };
+  },
+
+  // --[ Pattern matching ]---------------------------------------------
+  Match(expression, cases) {
+    return { expression, cases };
+  },
+
+  MatchCase(pattern, expression) {
+    return { pattern, expression };
+  },
+
+  MatchBind(identifier) {
+    return { identifier };
+  },
+
+  MatchEquals(expression) {
+    return { expression };
+  },
+
+  MatchTagged(tag, patterns) {
+    return { tag, patterns };
+  },
+
+  MatchVector(items) {
+    return { items };
+  },
+
+  MatchVectorSpread(pattern) {
+    return { pattern };
+  },
+
+  MatchVectorElement(pattern) {
+    return { pattern };
+  },
+
+  MatchAny() {
+    return { };
   },
 
   // --[ Declarations ]-------------------------------------------------

--- a/source/vm/core-library/debug.js
+++ b/source/vm/core-library/debug.js
@@ -8,7 +8,7 @@
 //----------------------------------------------------------------------
 
 module.exports = (furipota) => {
-  const { nativeModule, native, tagged, Stream } = furipota.primitives;
+  const { nativeModule, native, Stream } = furipota.primitives;
 
   const { inspect } = require('util');
   const { compact } = require('../../utils');

--- a/source/vm/core-library/filesystem.js
+++ b/source/vm/core-library/filesystem.js
@@ -8,17 +8,19 @@
 //----------------------------------------------------------------------
 
 module.exports = (furipota) => {
-  const { nativeModule, native, nativeThunk, tagged, stream, textToPath, pathToText } = furipota.primitives;
+  const { nativeModule, native, nativeThunk, stream, textToPath, pathToText, variant, tagged, TPath, isString } = furipota.primitives;
   const fsw = require('../../wrappers/fs');
   const { compact } = require('../../utils');
   const fs = require('fs');
   const Maybe = require('folktale/maybe');
 
+  const TEncoding = variant('Encoding', [isString]);
+
 
   return nativeModule('core:filesystem', {
     find:
-    native('find', [['^Path'], {
-        'base-directory?': '^Path',
+    native('find', [[TPath], {
+        'base-directory?': TPath,
         'silent?': 'Boolean',
         'strict?': 'Boolean',
         'match-directories?': 'Boolean',
@@ -55,7 +57,7 @@ module.exports = (furipota) => {
     ),
 
     'make-directory':
-    native('make-directory', [['^Path'], { 'mode?': 'Number' }],
+    native('make-directory', [[TPath], { 'mode?': 'Number' }],
       'creates a path in a file system',
       (ctx, path, { mode }) => {
         return stream(async (producer) => {
@@ -72,7 +74,7 @@ module.exports = (furipota) => {
     ),
 
     'remove':
-    native('remove', [['^Path'], {}],
+    native('remove', [[TPath], {}],
       'removes a path from the file system',
       (ctx, path, options) => {
         return stream(async (producer) => {
@@ -88,7 +90,7 @@ module.exports = (furipota) => {
     ),
 
     'copy':
-    native('copy', [['^Path'], { to: '^Path', 'overwrite?': 'Boolean' }],
+    native('copy', [[TPath], { to: TPath, 'overwrite?': 'Boolean' }],
       'copies a tree to another destination',
       (ctx, path, { to, overwrite }) => {
         return stream(async (producer) => {
@@ -105,7 +107,7 @@ module.exports = (furipota) => {
     ),
 
     'list-directory':
-    native('list-directory', [['^Path'], {}],
+    native('list-directory', [[TPath], {}],
       'lists the immediate contents of a directory',
       (ctx, path, _options) => {
         return stream(async (producer) => {
@@ -122,7 +124,7 @@ module.exports = (furipota) => {
     ),
 
     'exists':
-    native('exists', [['^Path'], {}],
+    native('exists', [[TPath], {}],
       'checks if a path exists',
       (ctx, path, _options) => {
         return fs.existsSync(pathToText(path));
@@ -130,8 +132,8 @@ module.exports = (furipota) => {
     ),
 
     'read':
-    native('read', [['^Path'], {
-        'encoding?': '^Encoding',
+    native('read', [[TPath], {
+        'encoding?': TEncoding,
         'mode?': 'Number',
         'start-at-byte?': 'Number',
         'end-at-byte?': 'Number'
@@ -170,8 +172,8 @@ module.exports = (furipota) => {
     ),
 
     'write':
-    native('write', [['^Path', 'Stream'], {
-        'default-encoding?': '^Encoding',
+    native('write', [[TPath, 'Stream'], {
+        'default-encoding?': TEncoding,
         'mode': 'Number',
         'start-at-byte': 'Number'
       }],
@@ -216,7 +218,7 @@ module.exports = (furipota) => {
     ),
 
     'symbolic-link':
-    native('symbolic-link', [['^Path'], { to: '^Path' }],
+    native('symbolic-link', [[TPath], { to: TPath }],
       'creates a symbolic link',
       (ctx, from, { to }) => {
         return stream(async (producer) => {
@@ -232,7 +234,7 @@ module.exports = (furipota) => {
     ),
 
     'unlink':
-    native('unlink', [['^Path'], {}],
+    native('unlink', [[TPath], {}],
       'removes a symbolic link',
       (ctx, path, _options) => {
         return stream(async (producer) => {
@@ -249,27 +251,27 @@ module.exports = (furipota) => {
 
     'Encoding': {
       'utf-8': nativeThunk('utf-8', 'an encoding for multibyte encoded Unicode characters', 
-        (ctx) => tagged('Encoding', {_: 'utf8'})
+        (ctx) => tagged(TEncoding, ['utf8'])
       ),
 
       'ascii': nativeThunk('ascii', 'an encoding for 7-bit ASCII data only',
-        (ctx) => tagged('Encoding', {_: 'ascii'})
+        (ctx) => tagged(TEncoding, ['ascii'])
       ),
 
       'utf-16-little-endian': nativeThunk('utf-16-little-endian', '2 or 4 bytes, little-endian encoded Unicode characters',
-        (ctx) => tagged('Encoding', {_: 'utf16le'})
+        (ctx) => tagged(TEncoding, ['utf16le'])
       ),
 
       'base64': nativeThunk('base64', 'an encoding in base 64',
-        (ctx) => tagged('Encoding', {_: 'base64'})
+        (ctx) => tagged(TEncoding, ['base64'])
       ),
 
       'latin1': nativeThunk('latin1', 'a way of encoding th Buffer into a one-byte encoded string',
-        (ctx) => tagged('Encoding', {_: 'latin1'})
+        (ctx) => tagged(TEncoding, ['latin1'])
       ),
 
       'hex': nativeThunk('hex', 'encode each byte as two hexadecimal characters',
-        (ctx) => tagged('Encoding', {_: 'hex'})
+        (ctx) => tagged(TEncoding, ['hex'])
       )
     }
   });

--- a/source/vm/core-library/operating-system.js
+++ b/source/vm/core-library/operating-system.js
@@ -8,7 +8,10 @@
 //----------------------------------------------------------------------
 
 module.exports = (furipota) => {
-  const { nativeModule, native, nativeThunk, textToPath, shell } = furipota.primitives;
+  const { 
+    nativeModule, native, nativeThunk, textToPath, TPath, shell,
+    TShellError, TShellExitCode, TShellOutput, TShellErrorOutput
+  } = furipota.primitives;
 
   return nativeModule('core:operating-system', {
     'current-directory':
@@ -22,8 +25,8 @@ module.exports = (furipota) => {
     ),
 
     'run':
-    native('run', [['^Path', 'Vector'], {
-        'working-directory?': '^Path',
+    native('run', [[TPath, 'Vector'], {
+        'working-directory?': TPath,
         'environment?': 'Record',
         'user-id?': 'Number',
         'group-id?': 'Number'
@@ -32,6 +35,28 @@ module.exports = (furipota) => {
       (ctx, command, args, options) => {
         return shell(command, args, options);
       }
-    )
+    ),
+
+    'Shell': {
+      'Error':
+      nativeThunk('Shell-Error', 'represents errors in shell',
+        (ctx) => TShellError
+      ),
+
+      'Exit-Code':
+      nativeThunk('Shell-Exit-Code', 'represents exit codes in shell',
+        (ctx) => TShellExitCode
+      ),
+
+      'Output':
+      nativeThunk('Shell-Output', 'represents output streams in shell',
+        (ctx) => TShellOutput
+      ),
+
+      'Error-Output':
+      nativeThunk('Shell-Error-Output', 'represents error output streams in shell',
+        (ctx) => TShellErrorOutput
+      )
+    }
   });
 };

--- a/source/vm/core-library/path.js
+++ b/source/vm/core-library/path.js
@@ -8,7 +8,7 @@
 //----------------------------------------------------------------------
 
 module.exports = (furipota) => {
-  const { nativeModule, native, tagged, pathToText, textToPath, typeMatches } = furipota.primitives;
+  const { nativeModule, native, pathToText, textToPath, typeMatches, TPath } = furipota.primitives;
   const Path = require('path');
 
   return nativeModule('core:path', {
@@ -21,7 +21,7 @@ module.exports = (furipota) => {
     ),
 
     'to-text':
-    native('to-text', [['^Path'], {}],
+    native('to-text', [[TPath], {}],
       'converts a filesystem path to a piece of text',
       (ctx, path, _options) => {
         return pathToText(path);
@@ -29,7 +29,7 @@ module.exports = (furipota) => {
     ),
 
     'is-root':
-    native('is-root', [['^Path'], {}],
+    native('is-root', [[TPath], {}],
       'tests if a path is a root path',
       (ctx, path, _options) => {
         const data = Path.parse(pathToText(path));
@@ -38,7 +38,7 @@ module.exports = (furipota) => {
     ),
 
     'is-relative':
-    native('is-relative', [['^Path'], {}],
+    native('is-relative', [[TPath], {}],
       'tests if a path is a relative path',
       (ctx, path, _options) => {
         return !Path.isAbsolute(pathToText(path));
@@ -46,7 +46,7 @@ module.exports = (furipota) => {
     ),
 
     'is-absolute':
-    native('is-absolute', [['^Path'], {}],
+    native('is-absolute', [[TPath], {}],
       'tests if a path is an absolute path',
       (ctx, path, _options) => {
         return Path.isAbsolute(pathToText(path));
@@ -62,7 +62,7 @@ module.exports = (furipota) => {
     ),
 
     relative:
-    native('relative', [['^Path'], { to: '^Path' }],
+    native('relative', [[TPath], { to: TPath }],
       'returns a path relative to the destination',
       (ctx, from, { to }) => {
         return textToPath(Path.relative(...[from, to].map(pathToText)));
@@ -70,7 +70,7 @@ module.exports = (furipota) => {
     ),
 
     directory:
-    native('directory', [['^Path'], {}],
+    native('directory', [[TPath], {}],
       'returns the directory portion of a path',
       (ctx, path, _options) => {
         return textToPath(Path.dirname(pathToText(path)));
@@ -78,7 +78,7 @@ module.exports = (furipota) => {
     ),
 
     normalize:
-    native('normalize', [['^Path'], {}],
+    native('normalize', [[TPath], {}],
       'returns a normalised version of a path',
       (ctx, path, _options) => {
         return textToPath(Path.normalize(pathToText(path)));
@@ -86,7 +86,7 @@ module.exports = (furipota) => {
     ),
 
     'change-extension':
-    native('change-extension', [['Text', '^Path'], {}],
+    native('change-extension', [['Text', TPath], {}],
       'changes the extension portion of a path',
       (ctx, extension, path, _options) => {
         ctx.assert(/^\./.test(extension) && !extension.includes(Path.separator), `Invalid file extension ${extension}.`);
@@ -98,10 +98,10 @@ module.exports = (furipota) => {
     ),
 
     '/':
-    native('/', [['^Path', 'Any'], {}],
+    native('/', [[TPath, 'Any'], {}],
       'joins paths and segments',
       (ctx, base, segment, _options) => {
-        if (typeMatches('^Path', segment)) {
+        if (typeMatches(TPath, segment)) {
           return textToPath(Path.join(...[base, segment].map(pathToText)));
         } else if (typeMatches('Text', segment) && !segment.includes(Path.separator)) {
           return textToPath(Path.join(pathToText(base), segment));

--- a/source/vm/core-library/record.js
+++ b/source/vm/core-library/record.js
@@ -8,7 +8,7 @@
 //----------------------------------------------------------------------
 
 module.exports = (furipota) => {
-  const { nativeModule, native, nativeThunk, tagged, ok, error } = furipota.primitives;
+  const { nativeModule, native, nativeThunk, ok, error } = furipota.primitives;
   const hasOwn = Function.call.bind(Object.prototype.hasOwnProperty);
 
   return nativeModule('core:record', {

--- a/source/vm/core-library/terminal.js
+++ b/source/vm/core-library/terminal.js
@@ -8,7 +8,7 @@
 //----------------------------------------------------------------------
 
 module.exports = (furipota) => {
-  const { nativeModule, native, unit, Stream } = furipota.primitives;
+  const { nativeModule, native, unit, Stream, TShellOutput, TShellErrorOutput } = furipota.primitives;
 
   return nativeModule('core:terminal', {
     show:
@@ -17,11 +17,13 @@ module.exports = (furipota) => {
       (ctx, stream, _options) => {
         stream.subscribe({
           Value: async (x) => {
-            ctx.assertType('Text | Buffer', x);
-            process.stdout.write(x)
+            ctx.assertType([TShellOutput, TShellErrorOutput], x);
+            const value = x.values[0];
+            ctx.assertType(['Text', 'Buffer'], value);
+            process.stdout.write(value);
           },
           Error: (x) => {
-            ctx.assertType('Text | Buffer', x);
+            ctx.assertType(['Text', 'Buffer'], x);
             process.stderr.write(x)
           },
           Close: () => {}

--- a/source/vm/core-library/text.js
+++ b/source/vm/core-library/text.js
@@ -8,7 +8,7 @@
 //----------------------------------------------------------------------
 
 module.exports = (furipota) => {
-  const { nativeModule, native, tagged } = furipota.primitives;
+  const { nativeModule, native } = furipota.primitives;
 
   return nativeModule('core:text', {
     concatenate:

--- a/source/vm/core-library/vector.js
+++ b/source/vm/core-library/vector.js
@@ -8,7 +8,7 @@
 //----------------------------------------------------------------------
 
 module.exports = (furipota) => {
-  const { nativeModule, native, tagged, ok, error } = furipota.primitives;
+  const { nativeModule, native, ok, error } = furipota.primitives;
 
   const at = (ctx, index, vector) => {
     ctx.assert(index >= 1, 'Indexes should be 1-based and positive');

--- a/source/vm/parser.ometajs
+++ b/source/vm/parser.ometajs
@@ -17,7 +17,8 @@ var reserved = [
   'if', 'then', 'else',
   'and', 'or', 'not',
   'default',
-  'do', 'call', 'action', 'bind', 'return'
+  'do', 'call', 'action', 'bind', 'return',
+  'match', 'case', 'with'
 ];
 
 function isValid(id) {
@@ -128,8 +129,7 @@ ometa FuripotaParser {
   Lambda = (ws Identifier)+:as (ws '@' ws Identifier)?:r ws seq('->') ws expression:e
          -> makeLambda(as.concat([r || ast.Identifier('_')]), e),
 
-  Tagged = '^' Identifier:i ws simpleExpression:e
-           -> ast.Tagged(i, e),
+  Tagged = '^' Identifier:i (ws simpleExpression)*:es -> ast.Tagged(i, es),
 
 
   // --[ Declarations ]
@@ -164,6 +164,7 @@ ometa FuripotaParser {
              | Lambda
              | Let
              | IfThenElse
+             | Match
              | Pipe
              | Do,
 
@@ -260,6 +261,31 @@ ometa FuripotaParser {
                    | Hole
                    | Identifier:i               -> ast.Variable(i)
                    | '(' ws expression:a ws ')' -> a,
+
+  Match = kw('match') ws expression:e ws kw('with') 
+          (ws CaseExpression)+:cs 
+          (ws kw('default') ws expression)?:me 
+       -> ast.Match(e, cs.concat(me ? [ast.MatchCase(ast.MatchAny(), me)] : [])),
+
+  CaseExpression = kw('case') ws CasePattern:p ws kw('then') ws expression:e -> ast.MatchCase(p, e),
+
+  CasePattern = kw('let') ws Identifier:i  -> ast.MatchBind(i)
+              | '^' caseTagged:a           -> ast.MatchTagged(a[0], a[1])
+              | CaseVector:v               -> ast.MatchVector(v)
+              | '_'                        -> ast.MatchAny()
+              | simpleExpression:a         -> ast.MatchEquals(a),
+
+  caseTagged = memberExpression:m (ws CasePattern)*:ps -> [m, ps]
+             | Identifier:i (ws CasePattern)*:ps       -> [ast.Variable(i), ps],
+
+  CaseVector = '[' ws ']' -> []
+             | '[' CasePattern:e (ws ',' ws CasePattern)*:es (ws ',' ws caseVectorLast)?:le ']' 
+               -> [e].concat(es).map(ast.MatchVectorElement).concat(le ? [le] : []),
+
+  caseVectorLast = seq('...') kw('let') ws Identifier:i -> ast.MatchVectorSpread(ast.MatchBind(i))
+                 | seq('...') '_'                       -> ast.MatchVectorSpread(ast.MatchAny())
+                 | CasePattern:p                        -> ast.MatchVectorElement(p),
+
 
 
   // --[ Entry points ]

--- a/source/vm/parser.ometajs
+++ b/source/vm/parser.ometajs
@@ -18,7 +18,7 @@ var reserved = [
   'and', 'or', 'not',
   'default',
   'do', 'call', 'action', 'bind', 'return',
-  'match', 'case', 'with'
+  'match', 'case', 'with', 'any'
 ];
 
 function isValid(id) {
@@ -272,7 +272,7 @@ ometa FuripotaParser {
   CasePattern = kw('let') ws Identifier:i  -> ast.MatchBind(i)
               | '^' caseTagged:a           -> ast.MatchTagged(a[0], a[1])
               | CaseVector:v               -> ast.MatchVector(v)
-              | '_'                        -> ast.MatchAny()
+              | kw('any')                  -> ast.MatchAny()
               | simpleExpression:a         -> ast.MatchEquals(a),
 
   caseTagged = memberExpression:m (ws CasePattern)*:ps -> [m, ps]
@@ -283,7 +283,7 @@ ometa FuripotaParser {
                -> [e].concat(es).map(ast.MatchVectorElement).concat(le ? [le] : []),
 
   caseVectorLast = seq('...') kw('let') ws Identifier:i -> ast.MatchVectorSpread(ast.MatchBind(i))
-                 | seq('...') '_'                       -> ast.MatchVectorSpread(ast.MatchAny())
+                 | seq('...') kw('any')                 -> ast.MatchVectorSpread(ast.MatchAny())
                  | CasePattern:p                        -> ast.MatchVectorElement(p),
 
 

--- a/source/vm/passes/desugar-application.js
+++ b/source/vm/passes/desugar-application.js
@@ -10,7 +10,7 @@
 const ast = require('../ast');
 
 
-const desugarApplication = (node) =>
+const desugarApplication = (node) => 
   node.matchWith({
     Seq: ({ items }) =>
       ast.Seq(items.map(desugarApplication)),
@@ -62,8 +62,38 @@ const desugarApplication = (node) =>
     Lambda: ({ value, options, expression }) =>
       ast.Lambda(value, options, desugarApplication(expression)),
 
-    Tagged: ({ tag, value }) =>
-      ast.Tagged(tag, desugarApplication(value)),
+    Tagged: ({ tag, predicates }) =>
+      ast.Tagged(tag, predicates.map(desugarApplication)),
+
+    Match: ({ expression, cases }) =>
+      ast.Match(
+        desugarApplication(expression),
+        cases.map(desugarApplication)
+      ),
+
+    MatchCase: ({ pattern, expression }) =>
+      ast.MatchCase(desugarApplication(pattern), desugarApplication(expression)),
+
+    MatchBind: ({ identifier }) =>
+      ast.MatchBind(identifier),
+
+    MatchEquals: ({ expression }) =>
+      ast.MatchEquals(desugarApplication(expression)),
+
+    MatchTagged: ({ tag, patterns }) =>
+      ast.MatchTagged(desugarApplication(tag), patterns.map(desugarApplication)),
+
+    MatchVector: ({ items }) =>
+      ast.MatchVector(items.map(desugarApplication)),
+
+    MatchVectorSpread: ({ pattern }) =>
+      ast.MatchVectorSpread(desugarApplication(pattern)),
+
+    MatchVectorElement: ({ pattern }) =>
+      ast.MatchVectorElement(desugarApplication(pattern)),
+
+    MatchAny: () => 
+      ast.MatchAny(),
 
     Define: ({ id, expression, documentation }) =>
       ast.Define(id, desugarApplication(expression), documentation),

--- a/source/vm/passes/desugar-holes.js
+++ b/source/vm/passes/desugar-holes.js
@@ -177,8 +177,44 @@ const desugarHoles = (bindings, node) =>
     Lambda: ({ value, options, expression }) =>
       ast.Lambda(value, options, desugarHoles(bindings, expression)),
 
-    Tagged: ({ tag, value }) =>
-      ast.Tagged(tag, desugarHoles(bindings, value)),
+    Tagged: ({ tag, predicates }) =>
+      ast.Tagged(tag, predicates.map(x => desugarHoles(bindings, x))),
+
+    Match: ({ expression, cases }) =>
+      ast.Match(
+        desugarHoles(bindings, expression),
+        cases.map(x => desugarHoles(bindings, x))
+      ),
+
+    MatchCase: ({ pattern, expression }) =>
+      ast.MatchCase(
+        desugarHoles(bindings, pattern),
+        desugarHoles(bindings, expression)
+      ),
+
+    MatchBind: ({ identifier }) =>
+      ast.MatchBind(identifier),
+
+    MatchEquals: ({ expression }) =>
+      ast.MatchEquals(desugarHoles(bindings, expression)),
+
+    MatchTagged: ({ tag, patterns }) =>
+      ast.MatchTagged(
+        desugarHoles(bindings, tag),
+        patterns.map(x => desugarHoles(bindings, x))
+      ),
+
+    MatchVector: ({ items }) =>
+      ast.MatchVector(items.map(x => desugarHoles(bindings, x))),
+
+    MatchVectorSpread: ({ pattern }) =>
+      ast.MatchVectorSpread(desugarHoles(bindings, pattern)),
+
+    MatchVectorElement: ({ pattern }) =>
+      ast.MatchVectorElement(desugarHoles(bindings, pattern)),
+
+    MatchAny: () => 
+      ast.MatchAny(),
 
     Define: ({ id, expression, documentation }) =>
       ast.Define(id, desugarHoles(bindings, expression), documentation),

--- a/source/vm/pretty-print.js
+++ b/source/vm/pretty-print.js
@@ -90,8 +90,45 @@ const prettyPrint = (node, depth = 0) => {
       return `${prettyPrint(value, depth)} @${prettyPrint(options, depth)} -> ${prettyPrint(expression, depth)}`
     },
 
-    Tagged: ({ tag, value }) => {
-      return `^${prettyPrint(tag, depth)} ${p(value, depth)}`;
+    Tagged: ({ tag, predicates }) => {
+      return `^${prettyPrint(tag, depth)} ${predicates.map(x => p(x, depth))}`;
+    },
+
+    Match: ({ expression, cases }) => {
+      const pad = ' '.repeat(depth + 2);
+      return `match ${prettyPrint(expression, depth)} with\n${pad}${cases.map(x => prettyPrint(x, depth + 2)).join('\n' + pad)}`;
+    },
+
+    MatchCase: ({ pattern, expression }) => {
+      return `case ${prettyPrint(pattern, depth)} then ${p(expression, depth)}`;
+    },
+
+    MatchBind: ({ identifier }) => {
+      return `let ${prettyPrint(identifier, depth)}`;
+    },
+
+    MatchEquals: ({ expression }) => {
+      return p(expression, depth);
+    },
+
+    MatchTagged: ({ tag, patterns }) => {
+      return `^${p(tag, depth)} ${patterns.map(x => p(x, depth)).join(' ')}`;
+    },
+
+    MatchVector: ({ items }) => {
+      return `[${items.map(x => p(x, depth)).join(', ')}]`;
+    },
+
+    MatchVectorSpread: ({ pattern }) => {
+      return `...${prettyPrint(pattern, depth)}`;
+    },
+
+    MatchVectorElement: ({ pattern }) => {
+      return prettyPrint(pattern, depth);
+    },
+
+    MatchAny: () => {
+      return '_';
     },
 
     Define: ({ id, expression }) => {

--- a/source/vm/types.js
+++ b/source/vm/types.js
@@ -7,7 +7,7 @@
 //
 //----------------------------------------------------------------------
 
-const { Primitive, Partial, Lambda, NativeThunk, Thunk, Tagged } = require('./intrinsics');
+const { Primitive, Lambda, NativeThunk, Thunk, Tagged, Variant } = require('./intrinsics');
 const Stream = require('../data/stream');
 const protoOf = Object.getPrototypeOf;
 const internalClass = Function.call.bind(Object.prototype.toString);
@@ -39,24 +39,28 @@ function getType(x) {
   :      typeof x === 'string'    ?  'Text'
   :      Array.isArray(x)         ?  'Vector'
   :      x instanceof Primitive   ?  'Primitive'
-  :      x instanceof Partial     ?  'Partial'
   :      x instanceof Lambda      ?  'Lambda'
   :      x instanceof NativeThunk ?  'Thunk'
   :      x instanceof Thunk       ?  'Thunk'
   :      x instanceof Buffer      ?  'Buffer'
   :      x instanceof Stream      ?  'Stream'
-  :      x instanceof Tagged      ?  `^${x.tag}`
+  :      x instanceof Tagged      ?  `^${x.tag.tag} instance`
+  :      x instanceof Variant     ?  `^${x.tag}`
   :      isPlainObject(x)         ?  'Record'
   :      /* else */                  `Unknown Type (JS ${classOf(x)})`;
 }
 
 function typeMatches(type, value) {
-  if (/\|/.test(type)) {
-    return type.split('|').map(x => x.trim()).some(t => typeMatches(t, value));
+  if (Array.isArray(type)) {
+    return type.some(t => typeMatches(t, value));
+  } else if (type instanceof Variant) {
+    return type.hasInstance(value);
   } else if (type === 'Any') {
     return !/^Unknown Type/.test(getType(value));
   } else if (type === 'Invokable') {
-    return ['Primitive', 'Partial', 'Lambda', 'Thunk'].includes(getType(value));
+    return ['Primitive', 'Lambda', 'Thunk'].includes(getType(value));
+  } else if (type === 'Variant') {
+    return value instanceof Variant;
   } else {
     return getType(value) === type;
   }

--- a/support/editors/vscode/furipota/syntaxes/furipota.tmLanguage.json
+++ b/support/editors/vscode/furipota/syntaxes/furipota.tmLanguage.json
@@ -4,11 +4,11 @@
   "patterns": [
     {
       "name": "keyword.control.furipota",
-      "match": "(?<!a-zA-Z0-9\\-)(define|import|core|plugin|export|as|let|in|if|then|else|and|or|not|default|do|call|action|bind|return)(?!a-zA-Z0-9\\-)"
+      "match": "(?<![a-zA-Z0-9\\-\\.\\^])(define|import|core|plugin|export|as|let|in|if|then|else|and|or|not|default|do|call|action|bind|return|match|with|case)(?![a-zA-Z0-9\\-])"
     },
     {
       "name": "constant.language.furipota",
-      "match": "(?<!a-zA-Z0-9\\-)(true|false)(?!a-zA-Z0-9\\-)"
+      "match": "(?<![a-zA-Z0-9\\-])(true|false)(?![a-zA-Z0-9\\-])"
     },
     {
       "name": "comment.line.heading.furipota",
@@ -16,31 +16,31 @@
     },
     {
       "name": "constant.numeric.integer.binary.furipota",
-      "match": "(?<!a-zA-Z0-9\\-)[\\-\\+]?0b[01][01_]*"
+      "match": "(?<![a-zA-Z0-9\\-])[\\-\\+]?0b[01][01_]*"
     },
     {
       "name": "constant.numeric.integer.octal.furipota",
-      "match": "(?<!a-zA-Z0-9\\-)[\\-\\+]?0o[0-7][0-7_]*"
+      "match": "(?<![a-zA-Z0-9\\-])[\\-\\+]?0o[0-7][0-7_]*"
     },
     {
       "name": "constant.numeric.integer.hexadecimal.furipota",
-      "match": "(?<!a-zA-Z0-9\\-)[\\-\\+]?0x[0-9a-fA-F][0-9a-fA-F_]*"
+      "match": "(?<![a-zA-Z0-9\\-])[\\-\\+]?0x[0-9a-fA-F][0-9a-fA-F_]*"
     },
     {
       "name": "constant.numeric.integer.furipota",
-      "match": "(?<!a-zA-Z0-9\\-)[\\-\\+]?[0-9][0-9_]*"
+      "match": "(?<![a-zA-Z0-9\\-])[\\-\\+]?[0-9][0-9_]*"
     },
     {
       "name": "constant.numeric.decimal.furipota",
-      "match": "(?<!a-zA-Z0-9\\-)[\\-\\+]?[0-9][0-9_]*(\\.[0-9][0-9_]*)?([eE][\\-\\+]?[0-9][0-9_]*)?"
+      "match": "(?<![a-zA-Z0-9\\-])[\\-\\+]?[0-9][0-9_]*(\\.[0-9][0-9_]*)?([eE][\\-\\+]?[0-9][0-9_]*)?"
     },
     {
       "name": "storage.type.furipota",
-      "match": "\\^[a-zA-Z][a-zA-Z0-9\\-]*"
+      "match": "\\^[a-zA-Z][a-zA-Z0-9\\-\\.]*"
     },
     {
       "name": "variable.name.furipota",
-      "match": "(?<!a-zA-Z0-9\\-)[a-zA-Z][a-zA-Z0-9\\-]*"
+      "match": "(?<![a-zA-Z0-9\\-])[a-zA-Z][a-zA-Z0-9\\-]*"
     },
     {
       "name": "keyword.symbol.furipota",
@@ -58,7 +58,7 @@
     },
     {
       "name": "keyword.record.furipota",
-      "match": "(?<!a-zA-Z0-9\\-)-[a-zA-Z][a-zA-Z\\-]*:?"
+      "match": "(?<![a-zA-Z0-9\\-])-[a-zA-Z][a-zA-Z\\-]*:?"
     },
     {
       "name": "comment.line",
@@ -66,7 +66,7 @@
     },
     {
       "name": "keyword.operator.furipota",
-      "match": "(?<!a-zA-Z0-9\\-)(===|=/=|>|>=|<|<=|\\+|-|\\*|/|@|\\|>|not|and|or|\\$)(?!a-zA-Z0-9\\-)"
+      "match": "(?<![a-zA-Z0-9\\-])(===|=/=|>|>=|<|<=|\\+|-|\\*|/|@|\\|>|not|and|or|\\$)(?!a-zA-Z0-9\\-)"
     }
   ],
   "scopeName": "source.furipota"

--- a/tests/parser/full/simple.yaml
+++ b/tests/parser/full/simple.yaml
@@ -2,7 +2,7 @@
 import """core"""
 
 define source = watch """src/*.js"""
-define compile = source |> babel _ @ -output-directory: """lib"""
+define compile = source |> babel
 ---
 result: OK
 ast:
@@ -23,10 +23,5 @@ ast:
     expression:
       !Pipe
       input: !Variable { id: !Identifier source }
-      transformation:
-        !Partial
-        callee: !Variable { id: !Identifier babel }
-        options:
-          !Record
-          - [!Keyword output-directory, !Text lib]
+      transformation: !Variable { id: !Identifier babel }
     documentation: ""

--- a/tests/parser/rules/pipe.yaml
+++ b/tests/parser/rules/pipe.yaml
@@ -1,4 +1,4 @@
-f """hello""" |> g _
+f """hello""" |> g
 ---
 result: OK
 rules: [Pipe, expression]
@@ -9,7 +9,4 @@ ast:
     callee: !Variable { id: !Identifier f }
     input: !Text "hello"
     options: !Record []
-  transformation: 
-    !Partial
-    callee: !Variable { id: !Identifier g }
-    options: !Record []
+  transformation: !Variable { id: !Identifier g }

--- a/tests/parser/run.js
+++ b/tests/parser/run.js
@@ -64,11 +64,6 @@ const Invoke = new yaml.Type('!Invoke', {
     ast.Invoke(callee, input, options)
 });
 
-const Partial = new yaml.Type('!Partial', {
-  kind: 'mapping',
-  construct: ({ callee, options }) => ast.Partial(callee, options)
-});
-
 const Pipe = new yaml.Type('!Pipe', {
   kind: 'mapping',
   construct: ({ input, transformation, options }) =>
@@ -96,7 +91,6 @@ const FuripotaSchema = yaml.Schema.create([
   Define,
   Import,
   Invoke,
-  Partial,
   Pipe,
   Variable,
   Program,


### PR DESCRIPTION
Furipota had open variants before, but used a flat namespace for all tag names. In hindsight, that was a pretty terrible idea because it's unmodular af. Also: good luck trying to model data that way.

Anyway, the major contribution of this patch is moving from flat namespace for tag names in the variants to unique tag names. Unfortunately, this is not a small change because a lot of the system depended on the previous format for structuring data. In addition, the `match` function would be much less usable with this change, so this patch introduces a `match` *special form* that does pattern matching, and uses something similar to Scala's extractors for matching non-intrinsic objects. Matching on records and destructuring are not yet supported, but both are planned.


## Open Variants with unique labels

Closed variants (e.g.: Haskell's `data x = A | B`) don't really make sense in dynamic languages, since you can neither really optimise the tags nor do exhaustiveness checks. Furipota's new version keeps the old open variants, except now the tags are unique values in the system, rather than names provided by the user in a flat namespace.

Having unique tags means that the following data constructors are *distinct* even though the provided, human-readable tag name is the same:

```
define A = ^Hello
define B = ^Hello
```


## Multi-parameter constructors

The previous constructor accepted exactly one parameter, since that's what you'd get when defining the function that'd get the value inside of the structure. Because we now have a special form for pattern matching, this limitation doesn't exist anymore, so constructors can take multiple arguments. Because constructors aren't `Invokable` by themselves (at least for now), a new `make` function is provided for constructing instances.

When defining a variant, you now have to provide predicates for each of the positional arguments you'll accept as well. A predicate is just a function that takes the value and returns `true` if it's acceptable, or `false` if it isn't.

```
import core "prelude"

define is-any x = true
define Tuple2 = ^Tuple2 is-any is-any

# `make` is a function in the `core` core module.
# It takes the Variant to construct, and an array with all positional arguments.
define my-tuple = make Tuple2 ["hello", 42]
```

## Pattern matching

As before, it's not possible to access the values of structures directly. Unlike before, now there's a special form for extracting these values. And that form is `match...with`:

```
define tuple x y = make Tuple2 x y
define result =
  match tuple "hello" 42 with
    case "hello" then "equality checking"
    case ["hello", ...let rest] then "vector special form"
    case ^Tuple2 (let x) 42 then "Variant special form"
    case any then "wildcard pattern"
    default "same as `case any then ...`"
```

## Other changes

This also updates the VSCode syntax definitions and fixes the tests previously broken by generalising holes for partial application.
